### PR TITLE
Add an input to specify the release's tag on the release repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: Boolean flag for if a release should be created on the target repo
     required: false
     default: true
+  tag:
+    description: A tag name to be used for the release. Defaults to the same tag as the current repo's release.
+    required: false
 outputs:
   branch_name:
     description: 'The branch name for the release'

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ async function main() {
   const octokit = new GitHub(token)
   const assetFileName = core.getInput('file');
   const branchName = core.getInput('branch');
+  const tagInput = core.getInput('tag');
   const tagAndRelease = core.getInput('tag-and-release', { required: false }) === 'true';
   const repoPath = path.resolve('./release-repo');
 
@@ -27,6 +28,9 @@ async function main() {
   const release = context.payload.release;
   const [owner, repo] = target.split('/');
   var tagName = release.tag_name;
+  if (tagInput) {
+    tagName = tagInput.trim();
+  }
   core.setOutput('tag_name', tagName);
   if (!tagAndRelease) {
     tagName = null;


### PR DESCRIPTION
This will allow a release (on the current repo) with tag `sdk-v2.3` to result in a release with tag `2.3` on the "release repo".